### PR TITLE
 fix: use std::invoke_result instead of deprecated/removed std::result_of

### DIFF
--- a/cpp/supercluster.hpp
+++ b/cpp/supercluster.hpp
@@ -344,25 +344,25 @@ namespace mapbox
             };
 
             template <typename F, typename V, typename Enable = void>
-            struct result_of_unary_visit
+            struct invoke_result_unary_visit
             {
-                using type = typename std::result_of<F(V &)>::type;
+                using type = typename std::invoke_result<F(V &)>::type;
             };
 
             template <typename F, typename V>
-            struct result_of_unary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
+            struct invoke_result_unary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
             {
                 using type = typename F::result_type;
             };
 
             template <typename F, typename V, typename Enable = void>
-            struct result_of_binary_visit
+            struct invoke_result_binary_visit
             {
-                using type = typename std::result_of<F(V &, V &)>::type;
+                using type = typename std::invoke_result<F(V &, V &)>::type;
             };
 
             template <typename F, typename V>
-            struct result_of_binary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
+            struct invoke_result_binary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
             {
                 using type = typename F::result_type;
             };
@@ -1028,14 +1028,14 @@ namespace mapbox
 
             // visitor
             // unary
-            template <typename F, typename V, typename R = typename detail::result_of_unary_visit<F, first_type>::type>
+            template <typename F, typename V, typename R = typename detail::invoke_result_unary_visit<F, first_type>::type>
             auto VARIANT_INLINE static visit(V const &v, F &&f)
                 -> decltype(detail::dispatcher<F, V, R, Types...>::apply_const(v, std::forward<F>(f)))
             {
                 return detail::dispatcher<F, V, R, Types...>::apply_const(v, std::forward<F>(f));
             }
             // non-const
-            template <typename F, typename V, typename R = typename detail::result_of_unary_visit<F, first_type>::type>
+            template <typename F, typename V, typename R = typename detail::invoke_result_unary_visit<F, first_type>::type>
             auto VARIANT_INLINE static visit(V &v, F &&f)
                 -> decltype(detail::dispatcher<F, V, R, Types...>::apply(v, std::forward<F>(f)))
             {
@@ -1044,14 +1044,14 @@ namespace mapbox
 
             // binary
             // const
-            template <typename F, typename V, typename R = typename detail::result_of_binary_visit<F, first_type>::type>
+            template <typename F, typename V, typename R = typename detail::invoke_result_binary_visit<F, first_type>::type>
             auto VARIANT_INLINE static binary_visit(V const &v0, V const &v1, F &&f)
                 -> decltype(detail::binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, std::forward<F>(f)))
             {
                 return detail::binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, std::forward<F>(f));
             }
             // non-const
-            template <typename F, typename V, typename R = typename detail::result_of_binary_visit<F, first_type>::type>
+            template <typename F, typename V, typename R = typename detail::invoke_result_binary_visit<F, first_type>::type>
             auto VARIANT_INLINE static binary_visit(V &v0, V &v1, F &&f)
                 -> decltype(detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, std::forward<F>(f)))
             {


### PR DESCRIPTION
Fixes #45 

As mentioned in #45, `std:result_of` has been deprecated in C++17 and removed in C++20, which causes builds on React Native 0.76 to fail when using the new architecture. The [CPPReference](https://en.cppreference.com/w/cpp/types/result_of) says that it should be replaced with `invoke_result` which has the same function signature. This PR just replaces the function calls from `result_of` to `invoke_result` and renames the structs to be prefixed with `invoke_result` instead of `result_of`.

The change seems to be working fine on a production app built with `0.76`, but I am not 100% sure if there's some underlying changes that could cause other issues.