### PR TITLE
fix: add --page-align linker flag for 16KB alignment on NDK 25+ for android

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -29,6 +29,23 @@ add_library(
 find_package(ReactAndroid REQUIRED CONFIG)
 find_library(log-lib log)
 
+# Determine if we're using Android NDK and support --page-align
+set(LINK_FLAGS "-Wl,--no-undefined")
+
+if(DEFINED ANDROID_NDK_VERSION)
+    string(REGEX MATCH "^([0-9]+)" NDK_MAJOR_VERSION "${ANDROID_NDK_VERSION}")
+    if(NDK_MAJOR_VERSION GREATER_EQUAL 25)
+        message(STATUS "Enabling --page-align (NDK ${NDK_MAJOR_VERSION} ≥ 25)")
+        list(APPEND LINK_FLAGS "-Wl,--page-align")
+    else()
+        message(STATUS "Skipping --page-align (NDK ${NDK_MAJOR_VERSION} < 25)")
+    endif()
+else()
+    message(STATUS "NDK version unknown; using default linker flags")
+endif()
+
+target_link_options(${PACKAGE_NAME} PRIVATE ${LINK_FLAGS})
+
 # Link JNI, JSI, LOG_LIB
 target_link_libraries(
   ${PACKAGE_NAME}


### PR DESCRIPTION
### Summary

This PR conditionally applies the `--page-align` linker flag when building with Android NDK 25+ to ensure native `.so` files are 16KB aligned.

This resolves alignment warnings shown during Play Console validation and improves memory-mapping performance on Android.

### What Changed

- Updated `android/CMakeLists.txt` to:
  - Parse `ANDROID_NDK_VERSION`
  - Apply `-Wl,--page-align` only when NDK >= 25
  - Keep `-Wl,--no-undefined` for safe default linking

### Why

Recent versions of the Play Console flag `.so` files that are not 16KB aligned. This change aligns with best practices while maintaining backward compatibility.

### Notes

- Compatible with older NDKs — does not apply `--page-align` unless NDK >= 25
- Safe for existing projects with no functional changes


